### PR TITLE
fix: do not add link if the target type is null

### DIFF
--- a/src/main/java/io/github/jtama/openrewrite/model/JavaSourceFileExcludedReport.java
+++ b/src/main/java/io/github/jtama/openrewrite/model/JavaSourceFileExcludedReport.java
@@ -1,0 +1,31 @@
+package io.github.jtama.openrewrite.model;
+
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.tree.JavaSourceFile;
+
+public class JavaSourceFileExcludedReport extends DataTable<JavaSourceFileExcludedReport.@NotNull Row> {
+
+    public JavaSourceFileExcludedReport(@Nullable Recipe recipe) {
+        super(recipe, "JavaSourceFile excluded",
+                "Records JavaSource files that were not handled by the recipe because they don't match the packages list submitted.");
+    }
+
+    public static class Row {
+
+        @Column(displayName = "Java source file path", description = "The Java source file path that was excluded.")
+        String fileSourcePath;
+
+        @Column(displayName = "Package name", description = "The excluded source file's package, if any.")
+        String packageName;
+
+        public Row(JavaSourceFile javaSourceFile) {
+            this.fileSourcePath = javaSourceFile.getSourcePath().toString();
+            this.packageName = javaSourceFile.getPackageDeclaration() == null ? "null"
+                    : javaSourceFile.getPackageDeclaration().getPackageName();
+        }
+    }
+}

--- a/src/main/java/io/github/jtama/openrewrite/model/JavaTypesNotHandledReport.java
+++ b/src/main/java/io/github/jtama/openrewrite/model/JavaTypesNotHandledReport.java
@@ -1,0 +1,30 @@
+package io.github.jtama.openrewrite.model;
+
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.tree.JavaType;
+
+public class JavaTypesNotHandledReport extends DataTable<JavaTypesNotHandledReport.@NotNull Row> {
+
+    public JavaTypesNotHandledReport(@Nullable Recipe recipe) {
+        super(recipe, "JavaType not handled",
+                "Records the JavaTypes that were not handled by the recipe.");
+    }
+
+    public static class Row {
+
+        @Column(displayName = "Java type class name", description = "The unhandled JavaType's class name.")
+        String className;
+
+        @Column(displayName = "Java type", description = "The unhandled Java Type.")
+        String javaType;
+
+        public Row(JavaType javaType) {
+            this.className = javaType.getClass().getName();
+            this.javaType = javaType.toString();
+        }
+    }
+}


### PR DESCRIPTION
* stops visiting tree if JavaSourceFile is not in a package (for Groovy or Kotlin)
* stops visiting tree if JavaSourceFile package is not in a package submited
* do not add link if JavaType is primitive
* add link for generic type with bounds
* added DataTable to list excluded JavaSourceFiles due to package exclusion
* added DataTable to list not handled JavaTypes

/closes #29 