### PR TITLE
Fix: Correct PR number access in cleanup-pr-preview workflow

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Define Surge Domain
         id: surge_domain
         run: |
-          PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}
-          SURGE_DOMAIN="pr-$PR_NUMBER-.project-graph-generator-preview.surge.sh"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          SURGE_DOMAIN="pr-$PR_NUMBER.project-graph-generator-preview.surge.sh"
           echo "SURGE_DOMAIN=$SURGE_DOMAIN" >> $GITHUB_OUTPUT
       - name: Remove from Surge
         run: npx surge teardown https://${{ steps.surge_domain.outputs.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -28,7 +28,7 @@ jobs:
         id: surge_domain
         run: |
           PR_NUMBER=${{ steps.pr.outputs.id }}
-          SURGE_DOMAIN="pr-$PR_NUMBER-.project-graph-generator-preview.surge.sh"
+          SURGE_DOMAIN="pr-$PR_NUMBER.project-graph-generator-preview.surge.sh"
           echo "SURGE_DOMAIN=$SURGE_DOMAIN" >> $GITHUB_OUTPUT
 
       - name: Deploy to Surge


### PR DESCRIPTION
Fixes #81\n\nThis PR corrects the way the PR number is accessed in the  workflow. Previously, it was trying to use , which is incorrect for a  event. The correct way is .