### PR TITLE
feat: Add repulsion force slider to graph visualization (#64)

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Define Surge Domain
         id: surge_domain
         run: |
-          PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}
-          SURGE_DOMAIN="pr-$PR_NUMBER-.project-graph-generator-preview.surge.sh"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          SURGE_DOMAIN="pr-$PR_NUMBER.project-graph-generator-preview.surge.sh"
           echo "SURGE_DOMAIN=$SURGE_DOMAIN" >> $GITHUB_OUTPUT
       - name: Remove from Surge
         run: npx surge teardown https://${{ steps.surge_domain.outputs.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -28,7 +28,7 @@ jobs:
         id: surge_domain
         run: |
           PR_NUMBER=${{ steps.pr.outputs.id }}
-          SURGE_DOMAIN="pr-$PR_NUMBER-.project-graph-generator-preview.surge.sh"
+          SURGE_DOMAIN="pr-$PR_NUMBER.project-graph-generator-preview.surge.sh"
           echo "SURGE_DOMAIN=$SURGE_DOMAIN" >> $GITHUB_OUTPUT
 
       - name: Deploy to Surge

--- a/src/main/resources/io/github/jtama/openrewrite/template.html
+++ b/src/main/resources/io/github/jtama/openrewrite/template.html
@@ -113,6 +113,17 @@
                    class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-indigo-600 hover:accent-indigo-700">
         </div>
 
+        <!-- Repulsion Force Slider -->
+        <div class="space-y-3 pt-2" id="repulsion-filter-container">
+            <div class="flex justify-between items-center">
+                <label for="repulsion-filter" class="block text-sm font-semibold text-slate-700">Repulsion Force</label>
+                <span id="repulsion-value"
+                      class="inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-indigo-100 bg-indigo-600 rounded">-50</span>
+            </div>
+            <input type="range" id="repulsion-filter" min="-200" max="0" step="1"
+                   class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-indigo-600 hover:accent-indigo-700">
+        </div>
+
         <!-- Color Number -->
         <div class="space-y-3 pt-2" id="top-communities-number-container">
             <div class="flex justify-between items-center">
@@ -501,6 +512,14 @@
         .attr("value", 30);
     topCommunitiesValueSpan.text(30);
 
+    const repulsionSlider = d3.select("#repulsion-filter");
+    const repulsionValueSpan = d3.select("#repulsion-value");
+    repulsionSlider
+        .attr("min", -200)
+        .attr("max", 0)
+        .attr("value", -50);
+    repulsionValueSpan.text(-50);
+
     let lastCommunityMethod = null;
 
     function applyFilters() {
@@ -585,6 +604,12 @@
     topCommunitiesSlider.on("input", function () {
         topCommunitiesValueSpan.text(this.value);
         applyFilters();
+    });
+
+    repulsionSlider.on("input", function () {
+        repulsionValueSpan.text(this.value);
+        simulation.force("charge").strength(this.value);
+        simulation.alpha(1).restart(); // Restart simulation to apply new force immediately
     });
 
 


### PR DESCRIPTION
Addresses #64. This PR introduces a new UI slider to the graph visualization page (class-diagram.html) that allows users to dynamically adjust the repulsion force between nodes in the force-directed layout. This helps in controlling the visual density of the graph, especially for large datasets.